### PR TITLE
Fix automatic generation of LTI keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Add :code:`django_lti_login` to :code:`settings.INSTALLED_APPS`.
 
 Add :code:`django_lti_login.backends.LTIAuthBackend` to :code:`settings.AUTHENTICATION_BACKENDS`.
 
-Examinate project in :code:`example` directory for more detailed example.
+Examine project in :code:`example` directory for more detailed example.
 Most relevant parts are marked with :code:`XXX: for django-lti-login`.
 
 Usage

--- a/django_lti_login/management/commands/add_lti_key.py
+++ b/django_lti_login/management/commands/add_lti_key.py
@@ -25,13 +25,16 @@ class Command(BaseCommand):
         lticlient = None
         for attempt in range(1000):
             # create new
-            if options['force'] and key:
-                try:
-                    lticlient = LTIClient.objects.get(key=key)
-                except LTIClient.DoesNotExist:
+            if key:
+                if options['force']:
+                    try:
+                        lticlient = LTIClient.objects.get(key=key)
+                    except LTIClient.DoesNotExist:
+                        lticlient = LTIClient(key=key)
+                else:
                     lticlient = LTIClient(key=key)
             else:
-                lticlient = LTIClient(key=key)
+                lticlient = LTIClient()
             if secret:
                 lticlient.secret = secret
             lticlient.description = desc

--- a/django_lti_login/management/commands/add_lti_key.py
+++ b/django_lti_login/management/commands/add_lti_key.py
@@ -10,9 +10,9 @@ class Command(BaseCommand):
         parser.add_argument('-f', '--force', action='store_true',
                             help="Overwrite existing keys")
         parser.add_argument('-k', '--key',
-                            help="The key. Only alphanumerals are allowed. Default: generate random")
+                            help="The key. Only alphanumericals are allowed. Default: generate random")
         parser.add_argument('-s', '--secret',
-                            help="A secret for the key. Only alphanumerals are allowed. Default: generate random")
+                            help="A secret for the key. Only alphanumericals are allowed. Default: generate random")
         parser.add_argument('-d', '--desc',
                             required=True,
                             help="A description for this key")
@@ -56,7 +56,7 @@ class Command(BaseCommand):
                 lticlient.save()
                 break
         else:
-            raise CommandError("Unable to create a valid LTI token wihtin %s tries" % (attempt,))
+            raise CommandError("Unable to create a valid LTI token within %s tries" % (attempt,))
 
 
         self.stdout.write(self.style.SUCCESS("Successfully created a new lti login key and a secret"))

--- a/django_lti_login/management/commands/delete_lti_keys.py
+++ b/django_lti_login/management/commands/delete_lti_keys.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
                 .format(c=lticlient)
             )
 
-        if not self.confirmation("Are you sure that you wan't to delete above keys?"):
+        if not self.confirmation("Are you sure that you want to delete above keys?"):
             self.stdout.write(self.style.WARNING("Aborted."))
             return
 


### PR DESCRIPTION
# Description

Changes in commit 39c638f1b836d3654507ab9e69d3dd31f06ff178 caused a situation where it was impossible to generate an LTI key with an automatically generated key name. Creating new keys was possible only by manually supplying the `-k` flag to `add_lti_key`. This pull request fixes that issue.

# Testing

After these changes, the following command will succeed again when executed inside the `example` directory

    python manage.py add_lti_key -d test

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [x] ~~I (developer) have created unit tests and the tests pass~~
- [x] ~~I (developer) have created functional tests (Selenium tests) if applicable~~
- [x] I (developer) have tested the changes manually
- [x] Reviewer has finished the code review
- [x] After the review, the developer has made changes accordingly
- [x] ~~Customer/Teacher has accepted the implementation of the feature~~