### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django >= 2.2.20, <3
+Django >= 2.2.20, <4
 django-settingsdict ~= 1.1.1
 oauthlib >=3.1.0, <4


### PR DESCRIPTION
# Description

Radar upgrade to Django version 3.2 requires lti-login to accept Django versions >3. The affects of this change has only
been tested in relation to Radar.


